### PR TITLE
Fix: Delete bytegoofy.com

### DIFF
--- a/easylistchina.txt
+++ b/easylistchina.txt
@@ -16521,7 +16521,6 @@ $script,subdocument,third-party,websocket,xmlhttprequest,domain=00ksw.com|01zww.
 ||huilan.xyz^
 ||9d6k.cn^
 ||mjpiqb.cn^
-||bytegoofy.com^
 ||cqyijiu.cn^
 ||jingcaiedc.cn^
 ||tchkcc.cn^


### PR DESCRIPTION
请求删除 `bytegoofy.com` 的域名。

该域名是字节跳动集团下很多静态资源托管的默认域名，类似于 google 的 `gstatic.com`，阿里的 `alicdn.com`。如果进行屏蔽，会导致很多字节跳动的网站无法打开。

目前发现该域名被添加的原因来自于这个 commit：https://github.com/easylist/easylistchina/commit/f2f97c1584e181b313b1a6b5f1be804870fdcabd 。而 `www.bokon.net` 网站使用了 `bytegoofy.com` 的场景是：

```
<script>
  | (function(){
  | var el = document.createElement("script");
  | el.src = "https://lf1-cdn-tos.bytegoofy.com/goofy/ttzz/push.js?6fb3364460ca57194a59ff50d58c6c768be63427c64b37399c1caa36515cd668b98df37a84379abf609a28026b3a02c46105340ab1158102ee2d72ba9c8cac00";
  | el.id = "ttzz";
  | var s = document.getElementsByTagName("script")[0];
  | s.parentNode.insertBefore(el, s);
  | })(window)
  | </script>

```

该方式是头条搜索站长平台所提供的网站自动收录功能，并不会投放广告信息

![image](https://user-images.githubusercontent.com/7554325/128660135-636673b3-6a80-4879-b61b-f0d52249453e.png)
