### PR TITLE
GitHub Linguist support for adblock filter files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.txt linguist-language=AdBlock linguist-detectable


### PR DESCRIPTION
GitHub has been supporting adblock syntax highlighting since September 5th. This PR will help you turn it on.

Further informations:
- Syntax highlighter repository: https://github.com/ameshkov/VscodeAdblockSyntax
- How Linguist works: https://github.com/github/linguist/blob/master/docs/how-linguist-works.md
- Linguist overrides: https://github.com/github/linguist/blob/master/docs/overrides.md
- Linguist commit: https://github.com/github/linguist/commit/e78ef71af3600f96b9a40a06511ebbe3797e7401

Enable statistics:
<img src="https://user-images.githubusercontent.com/57285466/189736511-15287650-f4de-4110-b0e6-22f0fcdb71fc.png" width="300px">
