### PR TITLE
Update easylistchina.txt

### DIFF
--- a/easylistchina.txt
+++ b/easylistchina.txt
@@ -1,4 +1,4 @@
-[Adblock Plus 2.0]
+! [Adblock Plus 2.0]
 ! Title: EasyList China
 ! Chinese supplement for the EasyList filters
 ! Last modified: %timestamp%


### PR DESCRIPTION
Fri Jan 27 16:26:07 2023 daemon.crit dnsmasq[9541]: bad option at line 1 of /var/etc/dnsmasq-adbyby.d/04-dnsmasq.adblock
Fri Jan 27 16:26:07 2023 daemon.crit dnsmasq[9541]: FAILED to start up

openwrt on R2s
使用 广告屏蔽大师 Plus+
更新规则后导致dnsmasq 启动失败

原因为第一行未添加注释