### PR TITLE
修复误伤 /qidian-admin

### DIFF
--- a/easylistchina.txt
+++ b/easylistchina.txt
@@ -561,7 +561,7 @@
 /pushstart.aspx|$subdocument,third-party
 /PushSystem/attached/image/*
 /qd/js/index/bannerTop.
-/qidian-ad
+/qidian-ad-*.js
 /QidianAdClient.
 /qiuyi-gg-wrapper-
 /qpxl.js


### PR DESCRIPTION
规则：`/qidian-ad`  最初添加来源：https://github.com/easylist/easylistchina/commit/77f56eec1996b51c45881547b073be41bf3fd892

来源页面：http://kan.sogou.com/player/180829645/


通过 WebArchive 档案馆源码查询 https://web.archive.org/web/20180809045228/http://kan.sogou.com/player/180829645/ ，当时需要屏蔽 `https://e.sogou.com/html/ext/qidian-ad-min.js` 该文件。 但由于规则过于宽泛，导致其他误伤，比如：`/qidian-admin/xxxx`

改为严谨匹配，请批准。