### PR TITLE
`douyin.com/`修复误伤，网站功能出现声画不同步的异常和用户投诉

### DIFF
--- a/easylistchina.txt
+++ b/easylistchina.txt
@@ -11112,7 +11112,6 @@ hxsame.hexun.com$domain=~quote.hexun.com
 szxx.com.cn###A0
 czys.top#?#.swiper-slide:-abp-has(.coveimg[src*=".gif"])
 raenonx.cc##.main_ads-content + div
-douyin.com#?#.page-recommend-container:-abp-has(span[style^="background"]:-abp-contains(广告))
 cnbeta.com.tw##.article-global
 hupu.com##div[class*="-banner_"]
 wenxuecity.com###gg_multitext


### PR DESCRIPTION
规则：`douyin.com/` 最初添加来源：[afb892](https://github.com/easylist/easylistchina/commit/afb892323190e46528b4866f264be35f35d6bf6b)

来源页面：https://www.douyin.com/?recommend=1

`douyin.com/?recommend=1`视频切换的交互较为复杂，单纯把广告视频隐藏但播放器实例仍然存在并继续播放，导致声画不同步的异常和用户投诉，给网站运营带来一定的风险。

暂时申请下掉该规则（近期研究一下如何确保不影响网站正常功能的前提下再加上），请批准。

